### PR TITLE
Search case-sensitively for keywords.

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -90,8 +90,9 @@ This is used by `global-hl-todo-mode'."
 
 (defvar hl-todo-keywords
   `(((lambda (_)
-       (and (re-search-forward hl-todo-regexp nil t)
-            (nth 8 (syntax-ppss)))) ; inside comment or string
+       (let (case-fold-search)
+         (and (re-search-forward hl-todo-regexp nil t)
+              (nth 8 (syntax-ppss))))) ; inside comment or string
      (1 (hl-todo-get-face) t))))
 
 (defun hl-todo-get-face ()


### PR DESCRIPTION
This avoids erroneous matches triggered by differently cases occurrences
of keywords, such as "Note" instead of "NOTE" and will avoid picking an
empty face for them.  See #5 for further details.