### PR TITLE
Improve keyword regex anchoring

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -106,7 +106,7 @@ follows the keyword."
         (concat "\\_<\\("
                 (regexp-opt (mapcar #'car hl-todo-keyword-faces) t)
                 (and (not (equal hl-todo-highlight-punctuation ""))
-                     (concat "[" hl-todo-highlight-punctuation "]?"))
+                     (concat "[" hl-todo-highlight-punctuation "]*"))
                 "\\)[[({:;.,?!]?\\_>"))
   (setq hl-todo--keywords
         `(((lambda (limit)

--- a/hl-todo.el
+++ b/hl-todo.el
@@ -91,10 +91,14 @@ This is used by `global-hl-todo-mode'."
                                (sexp :tag "Face")))))
 
 (defcustom hl-todo-highlight-punctuation ""
-  "String of punctuation characters to highlight after keywords.
+  "String of characters to highlight after keywords.
+
 Each of the characters appearing in this string is highlighted
 using the same face as the preceeding keyword when it directly
-follows the keyword."
+follows the keyword.
+
+Characters whose syntax class is `w' (which means word),
+including alphanumeric characters, cannot be used here."
   :group 'hl-todo
   :type 'string)
 

--- a/hl-todo.el
+++ b/hl-todo.el
@@ -105,9 +105,10 @@ follows the keyword."
   (setq hl-todo--regexp
         (concat "\\_<\\("
                 (regexp-opt (mapcar #'car hl-todo-keyword-faces) t)
+                "\\>"
                 (and (not (equal hl-todo-highlight-punctuation ""))
                      (concat "[" hl-todo-highlight-punctuation "]*"))
-                "\\)[[({:;.,?!]?\\_>"))
+                "\\)"))
   (setq hl-todo--keywords
         `(((lambda (limit)
              (let (case-fold-search)


### PR DESCRIPTION
- Anchor the keywords themselves, not the punctuation (fixes #27)
- Match a variable amount of punctuation at the end (highlights correctly "TODO?!?" with hl-todo-highlight-punctuation ":!?")