### PR TITLE
hl-todo-mode: Fontify using hl-todo--regexp only

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -140,14 +140,11 @@ including alphanumeric characters, cannot be used here."
       (hl-todo--setup)
     (font-lock-remove-keywords nil hl-todo--keywords))
   (when font-lock-mode
-    (if (and (fboundp 'font-lock-flush)
-             (fboundp 'font-lock-ensure))
-        (save-restriction
-          (widen)
-          (font-lock-flush)
-          (font-lock-ensure))
-      (with-no-warnings
-        (font-lock-fontify-buffer)))))
+    (save-excursion
+      (goto-char (point-min))
+      (while (re-search-forward hl-todo--regexp nil t)
+        (save-excursion
+	  (font-lock-fontify-region (match-beginning 0) (match-end 0) nil))))))
 
 ;;;###autoload
 (define-globalized-minor-mode global-hl-todo-mode


### PR DESCRIPTION
Previously we used `font-lock-flush` and `font-lock-ensure` instead.  Most built-in minor-modes that call `font-lock-add-keywords` (with `nil` as MODE), only call the former, which doesn't appear to always get the job done.  Additionally calling `font-lock-ensure` as we did isn`t much; it re-fontifies the complete buffer, which can be costly and it has been reported that it sometimes fails to actually do so.

Directly fontifying just our own keyword using `hl-todo--regexp` for the complete buffer seems to be a good compromise and should also be more reliable.

This should fix #22 and #26.

`smerge-mode` uses the same approach but that's not necessarily so because its author has the same doubts about `font-lock-flush` and `font-lock-ensure` that I have. That package uses a regexp that matches across more than one line, in which case things get even more complicated. Anyway, if it works for multi-line matches then matches within a single line should be no problem at all. Still, I would not necessarily recommend that all keyword-adding minor-modes use this approach.

This should be much faster than using  `font-lock-flush` and `font-lock-ensure` and not much slower than using just the former.