### PR TITLE
Fix end-of-word regexp anchoring

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -148,7 +148,7 @@ including alphanumeric characters, cannot be used here."
   (setq hl-todo--regexp
         (concat "\\(\\<"
                 "\\(" (mapconcat #'car hl-todo-keyword-faces "\\|") "\\)"
-                "\\(?:\\>\\|\\>?\\)"
+                "\\(?:\\>\\|\\>\\?\\)"
                 (and (not (equal hl-todo-highlight-punctuation ""))
                      (concat "[" hl-todo-highlight-punctuation "]*"))
                 "\\)"))


### PR DESCRIPTION
This fixes a regression introduced in f7d97056d17ef7fc04f4fa0b65a703d1d1a5a6b8, which caused, e.g., `TODOxyz` to be partially highlighted.