### PR TITLE
Check for font-lock-defaults before enabling

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -243,15 +243,16 @@ including alphanumeric characters, cannot be used here."
   :lighter ""
   :keymap hl-todo-mode-map
   :group 'hl-todo
+  (unless (and font-lock-mode font-lock-defaults)
+    (user-error "Cannot enable hl-todo-mode without font-lock"))
   (if hl-todo-mode
       (hl-todo--setup)
     (font-lock-remove-keywords nil hl-todo--keywords))
-  (when font-lock-mode
-    (save-excursion
-      (goto-char (point-min))
-      (while (hl-todo--search)
-        (save-excursion
-          (font-lock-fontify-region (match-beginning 0) (match-end 0) nil))))))
+  (save-excursion
+    (goto-char (point-min))
+    (while (hl-todo--search)
+      (save-excursion
+        (font-lock-fontify-region (match-beginning 0) (match-end 0) nil)))))
 
 ;;;###autoload
 (define-globalized-minor-mode global-hl-todo-mode


### PR DESCRIPTION
Currently there is an incompatibility between hl-todo-mode and enriched-mode, hl-todo-mode doesn't do a sufficient check whether font-lock-add-keywords can be used and wipes out the fontification done by enriched-mode, meaning no more pretty colors when opening `etc/enriched.txt`. This PR fixes this. See also https://debbugs.gnu.org/cgi/bugreport.cgi?bug=42138.