### PR TITLE
Fix typo

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -52,7 +52,7 @@
 
 ;;; Code:
 
-(require' cl-lib)
+(require 'cl-lib)
 
 (eval-when-compile
   (require 'subr-x))


### PR DESCRIPTION
Hi!

This is to fix a small typo.

The reader actually understands this form correctly as of Emacs 28:

```elisp
(read "(require' cl-lib)")
;; => (require 'cl-lib)
```

but nevertheless I think it should be better to avoid this.

Thanks!