### PR TITLE
Do not :inherit from hl-todo face

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -254,9 +254,9 @@ including alphanumeric characters, cannot be used here."
 
 (defun hl-todo--combine-face (face)
   (if (stringp face)
-      (list :inherit 'hl-todo
-            (if hl-todo-color-background :background :foreground)
-            face)
+      `((,(if hl-todo-color-background :background :foreground)
+         ,face)
+        hl-todo)
     face))
 
 (defvar-keymap hl-todo-mode-map


### PR DESCRIPTION
Prepend ((:foreground ...) hl-todo) faces instead of (:inherit hl-todo :foreground ...). Using the hl-todo face directly makes it a little easier to inspect the face property and to integrate with other packages like Embark.