### PR TITLE
Add flymake backend hl-todo-flymake

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -6,7 +6,7 @@
 ;; Homepage: https://github.com/tarsius/hl-todo
 ;; Keywords: convenience
 
-;; Package-Requires: ((emacs "25.1") (compat "29.1.3.4"))
+;; Package-Requires: ((emacs "25.1") (compat "29.1.4.2"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 


### PR DESCRIPTION
The backend must be registered as follows in the user configuration:

(add-hook 'flymake-diagnostic-functions #'flymake-hl-todo nil 'local)