### PR TITLE
Fix: Add version comment.

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -2,6 +2,7 @@
 
 ;; Copyright (C) 2013-2024 Jonas Bernoulli
 
+;; Version: 3.6.0
 ;; Author: Jonas Bernoulli <jonas@bernoul.li>
 ;; Homepage: https://github.com/tarsius/hl-todo
 ;; Keywords: convenience


### PR DESCRIPTION
Hi, i tried today to use magit-todo and find that hl-todo show as a version 0.

![imagen](https://github.com/tarsius/hl-todo/assets/8014685/edabff0c-41dc-45c6-8658-7ce80b12a2e6)

It's a sole line fix :).
