### PR TITLE
Define own hl-todo flymake-type

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -418,9 +418,10 @@ enabling `flymake-mode'."
                     (re-search-forward comment beg t)
                     (setq beg (point))))
                 (push (flymake-make-diagnostic
-                       buf beg end :note
+                       buf beg end 'hl-todo-flymake
                        (buffer-substring-no-properties beg end))
                       diags)))))))
+    (put 'hl-todo-flymake 'flymake-category 'flymake-note)
     (funcall report-fn (nreverse diags))))
 
 ;;;###autoload


### PR DESCRIPTION
This commit defines a new  flymake diagnostic type for `hl-todo` _(that
inherits from `flymake-note` )_. This allow the user to customize the face
used to highlight the todo keywords as shown in the screenshot below:

![Captura desde 2025-02-18 16-19-10](https://github.com/user-attachments/assets/116c693a-1a5b-4381-b8d3-cfd89ef78c53)
