### PR TITLE
fix: + matching requires adding escape characters

### DIFF
--- a/hl-todo.el
+++ b/hl-todo.el
@@ -275,6 +275,9 @@ See the function `hl-todo--regexp'."
                   (_       ""))
                 (and (not (equal hl-todo-highlight-punctuation ""))
                      (concat "[" hl-todo-highlight-punctuation "]"
+                             (if no-symbol
+                                 "\\"
+                               "")
                              (if hl-todo-require-punctuation "+" "*")))
                 "\\)")))
 


### PR DESCRIPTION
In grep matching, the `+` needs to be escaped in order to work as a quantifier.

This is the originally generated regular expression.
```bash
grep --color=auto -nH --null -e \(\\<\(HOLD\|TODO\|NEXT\|THEM\|PROG\|OKAY\|DONT\|FAIL\|DONE\|NOTE\|HACK\|TEMP\|FIXME\)\>\[|\]\+\)
```
This is the regular expression after my modification.
```bash
grep --color=auto -nH --null -e \(\\<\(HOLD\|TODO\|NEXT\|THEM\|PROG\|OKAY\|DONT\|FAIL\|DONE\|NOTE\|HACK\|TEMP\|FIXME\)\>\[|\]\\\+\)
```